### PR TITLE
Default checkbox font color to black for Dark mode visibility

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
         <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/font/ptserif.xml" value="0.1787037037037037" />
         <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/layout/activity_get_recipes.xml" value="0.1" />
         <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/layout/activity_main.xml" value="0.25" />
-        <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/layout/rv_layout.xml" value="0.2597173144876325" />
+        <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/layout/rv_layout.xml" value="0.1" />
         <entry key="..\:/Users/zarya/AndroidStudioProjects/QuickEats/app/src/main/res/menu/menu.xml" value="0.32135416666666666" />
       </map>
     </option>

--- a/app/src/main/res/layout/rv_layout.xml
+++ b/app/src/main/res/layout/rv_layout.xml
@@ -29,6 +29,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fontFamily="@font/oswald_med"
+            android:textColor="@color/black"
             android:checked="false" />
     </androidx.cardview.widget.CardView>
 


### PR DESCRIPTION
I have fixed the white text when in dark mode. The text was not visible. The default is now black for both light and dark modes.